### PR TITLE
Riorganizza dashboard e gestione squadre

### DIFF
--- a/Alienity/css/style.css
+++ b/Alienity/css/style.css
@@ -118,8 +118,13 @@ form button:hover {
   padding: 20px;
   border-radius: 15px;
   box-shadow: 0 0 10px #00d9ff;
-  margin: 15px auto;
-  max-width: 700px;
+  margin: 20px auto;
+  max-width: 900px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: stretch;
 }
 
 .card h3 {
@@ -443,3 +448,318 @@ button[value="rifiuta"]:hover {
   cursor: pointer;
 }
 
+
+/* LAYOUT DASHBOARD & PAGINE GESTIONE */
+.dashboard-content, .content {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 40px 20px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.role-chip {
+  align-self: center;
+  padding: 6px 18px;
+  border-radius: 999px;
+  background: rgba(57,255,20,0.15);
+  color: #39ff14;
+  font-size: 0.95rem;
+  letter-spacing: 0.5px;
+}
+
+.card.wide-card {
+  max-width: 100%;
+}
+
+.tabbed-panel {
+  max-width: 100%;
+  text-align: left;
+}
+
+.tab-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+
+.tab-button {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 1px solid rgba(57,255,20,0.6);
+  background: rgba(255,255,255,0.05);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.tab-button:hover,
+.tab-button.is-active {
+  background: linear-gradient(45deg, #39ff14, #00d9ff);
+  color: #000;
+  border-color: transparent;
+}
+
+.tab-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.tab-panel {
+  display: none;
+  gap: 20px;
+}
+
+.tab-panel.is-active {
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-description {
+  color: #a8a8c1;
+  margin: 0 auto 10px;
+  max-width: 520px;
+  text-align: center;
+}
+
+.panel-form {
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.panel-form label {
+  text-align: left;
+  display: block;
+  margin-bottom: 6px;
+  color: #00d9ff;
+}
+
+.table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  margin: 0;
+  border-collapse: collapse;
+  background: rgba(255,255,255,0.05);
+  border-radius: 15px;
+  overflow: hidden;
+}
+
+.data-table th,
+.data-table td {
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.data-table th {
+  background: #ff00ff;
+  color: #fff;
+  letter-spacing: 0.6px;
+}
+
+.data-table tr:nth-child(even) {
+  background: rgba(255,255,255,0.05);
+}
+
+.data-table tr:hover {
+  background: rgba(57,255,20,0.25);
+}
+
+.message-cell {
+  max-width: 320px;
+}
+
+.table-actions {
+  min-width: 220px;
+  text-align: center;
+}
+
+.inline-form {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.inline-form select,
+.inline-form input {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(57,255,20,0.4);
+  width: 100%;
+}
+
+.inline-form button {
+  width: auto;
+}
+
+.inline-form .button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.button-group button {
+  flex: 1;
+  min-width: 120px;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(45deg, #39ff14, #ff00ff);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+
+.button-group button:hover {
+  transform: translateY(-2px);
+}
+
+.button-group .secondary {
+  background: rgba(255,255,255,0.1);
+  border: 1px solid #ff004c;
+  color: #ff7b9c;
+}
+
+.inline-form.stacked {
+  background: rgba(255,255,255,0.05);
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 0 12px rgba(0,217,255,0.3);
+}
+
+.inline-form.stacked button {
+  width: 100%;
+}
+
+.status-chip {
+  display: inline-block;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  letter-spacing: 0.4px;
+  background: rgba(255,255,255,0.12);
+  color: #fff;
+}
+
+.status-chip.status-in-attesa {
+  background: rgba(255, 170, 0, 0.2);
+  color: #ffdd87;
+}
+
+.status-chip.status-accettata {
+  background: rgba(57,255,20,0.2);
+  color: #39ff14;
+}
+
+.status-chip.status-rifiutata {
+  background: rgba(255,0,70,0.25);
+  color: #ff7894;
+}
+
+.status-note {
+  color: #9aa0b8;
+  font-size: 0.9rem;
+}
+
+.team-card {
+  align-items: center;
+  text-align: center;
+}
+
+.link-button {
+  border: none;
+  background: transparent;
+  color: #39ff14;
+  font-size: 1.2rem;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 8px 18px;
+  border-radius: 999px;
+  transition: all 0.3s ease;
+}
+
+.link-button:hover {
+  background: rgba(57,255,20,0.15);
+  color: #00d9ff;
+}
+
+.collapsible {
+  display: none;
+  width: 100%;
+}
+
+.collapsible.is-visible {
+  display: block;
+}
+
+.team-list {
+  list-style: none;
+  padding: 0;
+  margin: 15px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.team-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(0,217,255,0.08);
+  backdrop-filter: blur(6px);
+}
+
+.team-member-name {
+  font-weight: 600;
+}
+
+.team-member-role {
+  font-size: 0.85rem;
+  color: #00d9ff;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.empty-state,
+.empty-state-text {
+  color: #a0a7c4;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .dashboard-content, .content {
+    padding: 30px 16px 60px;
+  }
+
+  .button-group button {
+    min-width: 140px;
+  }
+
+  .message-cell {
+    max-width: 240px;
+  }
+
+  .team-list li {
+    flex-direction: column;
+    gap: 8px;
+    text-align: center;
+  }
+}

--- a/Alienity/dashboard.php
+++ b/Alienity/dashboard.php
@@ -8,14 +8,26 @@ if (!isset($_SESSION["user_id"])) {
 }
 
 $id = $_SESSION["user_id"];
-$sql = "SELECT u.username, u.ruolo, t.nome as team 
-        FROM utenti u 
-        LEFT JOIN teams t ON u.team_id = t.id 
+$sql = "SELECT u.username, u.ruolo, u.squadra_id, s.nome AS team_nome
+        FROM utenti u
+        LEFT JOIN squadre s ON u.squadra_id = s.id
         WHERE u.id=?";
 $stmt = $conn->prepare($sql);
 $stmt->bind_param("i", $id);
 $stmt->execute();
 $user = $stmt->get_result()->fetch_assoc();
+
+$teamMembers = [];
+if (!empty($user['squadra_id'])) {
+    $memberSql = "SELECT username, ruolo FROM utenti WHERE squadra_id = ? ORDER BY FIELD(ruolo, 'Team Principal', 'Pro Racer', 'Racer'), username";
+    $memberStmt = $conn->prepare($memberSql);
+    $memberStmt->bind_param("i", $user['squadra_id']);
+    $memberStmt->execute();
+    $membersResult = $memberStmt->get_result();
+    while ($row = $membersResult->fetch_assoc()) {
+        $teamMembers[] = $row;
+    }
+}
 ?>
 <!DOCTYPE html>
 <html lang="it">
@@ -29,11 +41,32 @@ $user = $stmt->get_result()->fetch_assoc();
   <?php include "navbar.php"; ?>
 
   <main class="dashboard-content">
-    <h1>Benvenuto, <?php echo $user['username']; ?> 👽</h1>
-    <p>Ruolo: <b><?php echo $user['ruolo']; ?></b></p>
+    <h1>Benvenuto, <?php echo htmlspecialchars($user['username']); ?> 👽</h1>
+    <p class="role-chip">Ruolo: <b><?php echo htmlspecialchars($user['ruolo']); ?></b></p>
 
-    <?php if ($user['team']): ?>
-      <p>Appartieni alla squadra: <b><?php echo $user['team']; ?></b></p>
+    <?php if (!empty($user['team_nome']) && in_array($user['ruolo'], ['Racer', 'Pro Racer', 'Team Principal'])): ?>
+      <section class="card team-card">
+        <h3>La tua squadra</h3>
+        <button class="link-button" type="button" data-toggle="team-members">
+          <?php echo htmlspecialchars($user['team_nome']); ?>
+        </button>
+        <div id="team-members" class="collapsible">
+          <?php if (!empty($teamMembers)): ?>
+            <ul class="team-list">
+              <?php foreach ($teamMembers as $member): ?>
+                <li>
+                  <span class="team-member-name"><?php echo htmlspecialchars($member['username']); ?></span>
+                  <span class="team-member-role"><?php echo htmlspecialchars($member['ruolo']); ?></span>
+                </li>
+              <?php endforeach; ?>
+            </ul>
+          <?php else: ?>
+            <p class="empty-state">Non ci sono ancora piloti assegnati alla squadra.</p>
+          <?php endif; ?>
+        </div>
+      </section>
+    <?php elseif (!empty($user['team_nome'])): ?>
+      <p>Appartieni alla squadra: <b><?php echo htmlspecialchars($user['team_nome']); ?></b></p>
     <?php else: ?>
       <p>Non sei ancora assegnato a nessuna squadra.</p>
     <?php endif; ?>
@@ -45,6 +78,7 @@ $user = $stmt->get_result()->fetch_assoc();
       <?php elseif ($user['ruolo'] == "Team Principal"): ?>
         <h3>Gestione Team</h3>
         <p>Visualizza e gestisci i tuoi piloti.</p>
+        <a href="squadre.php" class="btn">Gestisci Squadre</a>
       <?php elseif ($user['ruolo'] == "Owner"): ?>
         <h3>Pannello Owner</h3>
         <p>Gestisci utenti, squadre e candidature.</p>
@@ -52,5 +86,7 @@ $user = $stmt->get_result()->fetch_assoc();
       <?php endif; ?>
     </section>
   </main>
+
+  <script src="js/script.js"></script>
 </body>
 </html>

--- a/Alienity/dashboard_admin.php
+++ b/Alienity/dashboard_admin.php
@@ -20,71 +20,67 @@ $candidature = $conn->query("SELECT * FROM candidature ORDER BY data_invio DESC"
   <div class="stars"></div>
   <?php include "navbar.php"; ?>
 
-  <main class="dashboard-content">
+  <main class="dashboard-content admin-dashboard">
     <h1>Gestione Candidature</h1>
 
-    <table>
-      <tr>
-        <th>Nome</th>
-        <th>Email</th>
-        <th>Messaggio</th>
-        <th>Data</th>
-        <th>Stato</th>
-        <th>Azione</th>
-      </tr>
-      <?php while ($row = $candidature->fetch_assoc()): ?>
-      <tr>
-        <td><?php echo htmlspecialchars($row['nome']); ?></td>
-        <td><?php echo htmlspecialchars($row['email']); ?></td>
-        <td><?php echo htmlspecialchars($row['messaggio']); ?></td>
-        <td><?php echo $row['data_invio']; ?></td>
-        <td><?php echo $row['stato']; ?></td>
-        <td>
-          <?php if ($row['stato'] == 'In attesa'): ?>
-            <form action="process_candidatura_admin.php" method="POST" style="display:inline;">
-              <input type="hidden" name="id" value="<?php echo $row['id']; ?>">
-              <td>
-  <?php if ($row['stato'] == 'In attesa'): ?>
-    <form action="process_candidatura_admin.php" method="POST">
-      <input type="hidden" name="id" value="<?php echo $row['id']; ?>">
-      <div class="action-buttons">
-        <button name="action" value="accetta">Accetta</button>
-        <button name="action" value="rifiuta">Rifiuta</button>
-      </div>
-    </form>
-  <?php elseif ($row['stato'] == 'Accettata'): ?>
-    <form action="crea_utente.php" method="POST">
-      <input type="hidden" name="email" value="<?php echo $row['email']; ?>">
-      <input type="hidden" name="nome" value="<?php echo $row['nome']; ?>">
-      <select name="ruolo" required>
-        <option value="Racer">Racer</option>
-        <option value="Pro Racer">Pro Racer</option>
-        <option value="Team Principal">Team Principal</option>
-      </select>
-      <input type="password" name="password" placeholder="Password temporanea" required>
-      <button type="submit">Crea Utente</button>
-    </form>
-  <?php endif; ?>
-</td>
-
-            </form>
-          <?php elseif ($row['stato'] == 'Accettata'): ?>
-            <form action="crea_utente.php" method="POST" style="display:inline;">
-              <input type="hidden" name="email" value="<?php echo $row['email']; ?>">
-              <input type="hidden" name="nome" value="<?php echo $row['nome']; ?>">
-              <select name="ruolo" required>
-                <option value="Racer">Racer</option>
-                <option value="Pro Racer">Pro Racer</option>
-                <option value="Team Principal">Team Principal</option>
-              </select>
-              <input type="password" name="password" placeholder="Password temporanea" required>
-              <button type="submit">Crea Utente</button>
-            </form>
+    <section class="card wide-card">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>Email</th>
+            <th>Messaggio</th>
+            <th>Data</th>
+            <th>Stato</th>
+            <th>Azione</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php if ($candidature && $candidature->num_rows > 0): ?>
+            <?php while ($row = $candidature->fetch_assoc()): ?>
+              <tr>
+                <td><?php echo htmlspecialchars($row['nome']); ?></td>
+                <td><?php echo htmlspecialchars($row['email']); ?></td>
+                <td class="message-cell"><?php echo nl2br(htmlspecialchars($row['messaggio'])); ?></td>
+                <td><?php echo htmlspecialchars($row['data_invio']); ?></td>
+                <td><span class="status-chip status-<?php echo strtolower(str_replace(' ', '-', $row['stato'])); ?>"><?php echo htmlspecialchars($row['stato']); ?></span></td>
+                <td class="table-actions">
+                  <?php if ($row['stato'] === 'In attesa'): ?>
+                    <form class="inline-form" action="process_candidatura_admin.php" method="POST">
+                      <input type="hidden" name="id" value="<?php echo $row['id']; ?>">
+                      <div class="button-group">
+                        <button name="action" value="accetta" type="submit">Accetta</button>
+                        <button name="action" value="rifiuta" type="submit" class="secondary">Rifiuta</button>
+                      </div>
+                    </form>
+                  <?php elseif ($row['stato'] === 'Accettata'): ?>
+                    <form class="inline-form stacked" action="crea_utente.php" method="POST">
+                      <input type="hidden" name="email" value="<?php echo htmlspecialchars($row['email']); ?>">
+                      <input type="hidden" name="nome" value="<?php echo htmlspecialchars($row['nome']); ?>">
+                      <select name="ruolo" required>
+                        <option value="Racer">Racer</option>
+                        <option value="Pro Racer">Pro Racer</option>
+                        <option value="Team Principal">Team Principal</option>
+                      </select>
+                      <input type="password" name="password" placeholder="Password temporanea" required>
+                      <button type="submit">Crea Utente</button>
+                    </form>
+                  <?php else: ?>
+                    <span class="status-note">Nessuna azione necessaria</span>
+                  <?php endif; ?>
+                </td>
+              </tr>
+            <?php endwhile; ?>
+          <?php else: ?>
+            <tr>
+              <td colspan="6" class="empty-state">Non ci sono candidature al momento.</td>
+            </tr>
           <?php endif; ?>
-        </td>
-      </tr>
-      <?php endwhile; ?>
-    </table>
+        </tbody>
+      </table>
+    </section>
   </main>
+
+  <script src="js/script.js"></script>
 </body>
 </html>

--- a/Alienity/js/script.js
+++ b/Alienity/js/script.js
@@ -1,4 +1,32 @@
-function toggleUserForm(id) {
-  const form = document.getElementById("user-form-" + id);
-  form.classList.toggle("active");
-}
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleButtons = document.querySelectorAll('[data-toggle]');
+  toggleButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const targetId = button.getAttribute('data-toggle');
+      if (!targetId) return;
+      const target = document.getElementById(targetId);
+      if (target) {
+        target.classList.toggle('is-visible');
+      }
+    });
+  });
+
+  const tabButtons = document.querySelectorAll('[data-panel-target]');
+  if (tabButtons.length > 0) {
+    const panels = document.querySelectorAll('[data-panel]');
+    tabButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const targetId = button.getAttribute('data-panel-target');
+        if (!targetId) return;
+
+        tabButtons.forEach((btn) => {
+          btn.classList.toggle('is-active', btn === button);
+        });
+
+        panels.forEach((panel) => {
+          panel.classList.toggle('is-active', panel.getAttribute('data-panel') === targetId);
+        });
+      });
+    });
+  }
+});

--- a/Alienity/squadre.php
+++ b/Alienity/squadre.php
@@ -7,26 +7,55 @@ if (!isset($_SESSION["user_id"]) || !in_array($_SESSION["ruolo"], ["Team Princip
     exit();
 }
 
-if ($_SERVER["REQUEST_METHOD"] == "POST") {
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
     if (isset($_POST["nuova_squadra"])) {
-        $nome = $_POST["nome"];
-        $categoria = $_POST["categoria"];
-        $stmt = $conn->prepare("INSERT INTO squadre (nome, categoria) VALUES (?, ?)");
-        $stmt->bind_param("ss", $nome, $categoria);
-        $stmt->execute();
+        $nome = trim($_POST["nome"] ?? '');
+        $categoria = $_POST["categoria"] ?? '';
+        if ($nome !== '' && $categoria !== '') {
+            $stmt = $conn->prepare("INSERT INTO squadre (nome, categoria) VALUES (?, ?)");
+            $stmt->bind_param("ss", $nome, $categoria);
+            $stmt->execute();
+        }
     }
 
     if (isset($_POST["assegna"])) {
-        $user_id = $_POST["user_id"];
-        $squadra_id = $_POST["squadra_id"];
-        $stmt = $conn->prepare("UPDATE utenti SET squadra_id=? WHERE id=?");
-        $stmt->bind_param("ii", $squadra_id, $user_id);
-        $stmt->execute();
+        $user_id = (int) ($_POST["user_id"] ?? 0);
+        $squadra_id = (int) ($_POST["squadra_id"] ?? 0);
+        if ($user_id > 0 && $squadra_id > 0) {
+            $stmt = $conn->prepare("UPDATE utenti SET squadra_id=? WHERE id=?");
+            $stmt->bind_param("ii", $squadra_id, $user_id);
+            $stmt->execute();
+        }
     }
 }
 
-$squadre = $conn->query("SELECT * FROM squadre");
-$utenti = $conn->query("SELECT id, username, ruolo, squadra_id FROM utenti WHERE ruolo IN ('Racer','Pro Racer')");
+$squadreList = [];
+$squadreQuery = $conn->query("SELECT id, nome, categoria FROM squadre ORDER BY nome");
+if ($squadreQuery) {
+    while ($row = $squadreQuery->fetch_assoc()) {
+        $squadreList[] = $row;
+    }
+}
+
+$utentiList = [];
+$utentiQuery = $conn->query("SELECT id, username, ruolo FROM utenti WHERE ruolo IN ('Racer','Pro Racer') ORDER BY username");
+if ($utentiQuery) {
+    while ($row = $utentiQuery->fetch_assoc()) {
+        $utentiList[] = $row;
+    }
+}
+
+$teamOverview = [];
+$overviewQuery = $conn->query("SELECT s.id, s.nome, s.categoria, GROUP_CONCAT(u.username ORDER BY u.username SEPARATOR ', ') AS membri
+    FROM squadre s
+    LEFT JOIN utenti u ON s.id = u.squadra_id
+    GROUP BY s.id, s.nome, s.categoria
+    ORDER BY s.nome");
+if ($overviewQuery) {
+    while ($row = $overviewQuery->fetch_assoc()) {
+        $teamOverview[] = $row;
+    }
+}
 ?>
 <!DOCTYPE html>
 <html lang="it">
@@ -42,85 +71,99 @@ $utenti = $conn->query("SELECT id, username, ruolo, squadra_id FROM utenti WHERE
   <main class="content">
     <h1>Gestione Squadre</h1>
 
-    <!-- Creazione nuova squadra -->
-    <div class="form-container">
-      <h2>Crea Nuova Squadra</h2>
-      <form method="POST">
-        <input type="hidden" name="nuova_squadra" value="1">
-        <input type="text" name="nome" placeholder="Nome squadra" required>
-        <select name="categoria">
-          <option value="GT">GT</option>
-          <option value="LMP2">LMP2</option>
-          <option value="Hypercar">Hypercar</option>
-        </select>
-        <button type="submit">Crea Squadra</button>
-      </form>
-    </div>
+    <section class="card tabbed-panel">
+      <div class="tab-buttons">
+        <button class="tab-button is-active" type="button" data-panel-target="panel-create">Crea squadra</button>
+        <button class="tab-button" type="button" data-panel-target="panel-assign">Assegna piloti</button>
+        <button class="tab-button" type="button" data-panel-target="panel-overview">Elenco squadre</button>
+      </div>
 
-    <!-- Assegna membri -->
-    <div class="form-container">
-      <h2>Assegna Membri</h2>
-      <form method="POST">
-        <input type="hidden" name="assegna" value="1">
-        <label>Seleziona Utente</label>
-        <select name="user_id" required>
-          <?php while ($u = $utenti->fetch_assoc()): ?>
-            <option value="<?php echo $u['id']; ?>">
-              <?php echo $u['username']; ?> (<?php echo $u['ruolo']; ?>)
-            </option>
-          <?php endwhile; ?>
-        </select>
+      <div class="tab-panels">
+        <section class="tab-panel is-active" data-panel="panel-create">
+          <h2>Crea nuova squadra</h2>
+          <p class="panel-description">Definisci nome e categoria per aggiungere una nuova squadra al campionato.</p>
+          <form class="panel-form" method="POST">
+            <input type="hidden" name="nuova_squadra" value="1">
+            <input type="text" name="nome" placeholder="Nome squadra" required>
+            <select name="categoria" required>
+              <option value="">Seleziona categoria</option>
+              <option value="GT">GT</option>
+              <option value="LMP2">LMP2</option>
+              <option value="Hypercar">Hypercar</option>
+            </select>
+            <button type="submit">Crea Squadra</button>
+          </form>
+        </section>
 
-        <label>Assegna a Squadra</label>
-        <select name="squadra_id" required>
-          <?php $squadre->data_seek(0); while ($s = $squadre->fetch_assoc()): ?>
-            <option value="<?php echo $s['id']; ?>">
-              <?php echo $s['nome']; ?> (<?php echo $s['categoria']; ?>)
-            </option>
-          <?php endwhile; ?>
-        </select>
+        <section class="tab-panel" data-panel="panel-assign">
+          <h2>Assegna piloti</h2>
+          <p class="panel-description">Scegli un pilota e seleziona la squadra di appartenenza.</p>
+          <form class="panel-form" method="POST">
+            <input type="hidden" name="assegna" value="1">
+            <label for="user_id">Seleziona pilota</label>
+            <select name="user_id" id="user_id" required>
+              <option value="">Scegli pilota</option>
+              <?php foreach ($utentiList as $u): ?>
+                <option value="<?php echo $u['id']; ?>">
+                  <?php echo htmlspecialchars($u['username']); ?> (<?php echo htmlspecialchars($u['ruolo']); ?>)
+                </option>
+              <?php endforeach; ?>
+            </select>
 
-        <button type="submit">Assegna</button>
-      </form>
-    </div>
+            <label for="squadra_id">Assegna a squadra</label>
+            <select name="squadra_id" id="squadra_id" required>
+              <option value="">Scegli squadra</option>
+              <?php foreach ($squadreList as $s): ?>
+                <option value="<?php echo $s['id']; ?>">
+                  <?php echo htmlspecialchars($s['nome']); ?> (<?php echo htmlspecialchars($s['categoria']); ?>)
+                </option>
+              <?php endforeach; ?>
+            </select>
 
-    <!-- Elenco squadre e membri -->
-    <div class="card">
-      <h2>Elenco Squadre</h2>
-      <table>
-        <tr>
-          <th>Squadra</th>
-          <th>Categoria</th>
-          <th>Membri</th>
-        </tr>
-        <?php
-        $result = $conn->query("
-          SELECT s.id, s.nome, s.categoria, u.username
-          FROM squadre s
-          LEFT JOIN utenti u ON s.id = u.squadra_id
-          ORDER BY s.id
-        ");
+            <button type="submit">Assegna pilota</button>
+          </form>
+        </section>
 
-        $current_team = null;
-        $members = [];
-        while ($row = $result->fetch_assoc()) {
-            if ($current_team !== $row['id']) {
-                if ($current_team !== null) {
-                    echo "<tr><td>{$team_name}</td><td>{$team_cat}</td><td>".implode(", ", $members)."</td></tr>";
-                }
-                $current_team = $row['id'];
-                $team_name = $row['nome'];
-                $team_cat = $row['categoria'];
-                $members = [];
-            }
-            if ($row['username']) $members[] = $row['username'];
-        }
-        if ($current_team !== null) {
-            echo "<tr><td>{$team_name}</td><td>{$team_cat}</td><td>".implode(", ", $members)."</td></tr>";
-        }
-        ?>
-      </table>
-    </div>
+        <section class="tab-panel" data-panel="panel-overview">
+          <h2>Elenco squadre</h2>
+          <p class="panel-description">Visualizza le squadre attive e i piloti assegnati.</p>
+          <div class="table-wrapper">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Squadra</th>
+                  <th>Categoria</th>
+                  <th>Piloti</th>
+                </tr>
+              </thead>
+              <tbody>
+                <?php if (!empty($teamOverview)): ?>
+                  <?php foreach ($teamOverview as $team): ?>
+                    <tr>
+                      <td><?php echo htmlspecialchars($team['nome']); ?></td>
+                      <td><?php echo htmlspecialchars($team['categoria']); ?></td>
+                      <td>
+                        <?php if (!empty($team['membri'])): ?>
+                          <?php echo htmlspecialchars($team['membri']); ?>
+                        <?php else: ?>
+                          <span class="empty-state-text">Nessun pilota assegnato</span>
+                        <?php endif; ?>
+                      </td>
+                    </tr>
+                  <?php endforeach; ?>
+                <?php else: ?>
+                  <tr>
+                    <td colspan="3" class="empty-state">Non ci sono squadre registrate.</td>
+                  </tr>
+                <?php endif; ?>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </section>
   </main>
+
+  <script src="js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- mostra i membri della squadra dalla dashboard con layout compatto e pulsante dedicato
- riallinea la tabella candidature dell'admin con bottoni ordinati e stati evidenziati
- trasforma la pagina Gestione Squadre in pannello a schede con form più leggibili e tabella piloti

## Testing
- php -l dashboard.php
- php -l dashboard_admin.php
- php -l squadre.php

------
https://chatgpt.com/codex/tasks/task_e_68cbfff0f388832297094a603539eb94